### PR TITLE
Added div around the main component to fix incomplete height bug

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,7 +8,9 @@ import { store } from "./redux/store.js";
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <div className="min-h-full">
+        <App />
+      </div>
     </Provider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
### Description:

On the Home page, with the dark background, this background would not stretch to the end of the page. Adding a div with the `h-full` class around the App component fixes this issue.